### PR TITLE
Update menuRSSIScreen.c

### DIFF
--- a/firmware/source/user_interface/menuRSSIScreen.c
+++ b/firmware/source/user_interface/menuRSSIScreen.c
@@ -77,7 +77,7 @@ static void updateScreen(void)
 		ucPrintCore(0, 3, buffer, FONT_SIZE_2, TEXT_ALIGN_RIGHT, false);
 
 		// Display "No Signal" when signal is lost
-		if (dBm <= -135)
+		if (dBm <= -150)
 		{
 		sprintf(buffer, "No Signal");
 		}


### PR DESCRIPTION
Hi Mike,
-135dBm as trigger for "No Signal" does not completely remove the message and results in flickering as in this video:
https://youtu.be/_hKhQP5FtNY

-150dBm should completely remove it.

Thanks